### PR TITLE
feat(Build): change apk name to FridaManager.apk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,6 @@ jobs:
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: ./gradlew bundleRelease --stacktrace
 
-      - name: Get release file aab path
-        id: releaseAab
-        run: echo "aabfile=$(find app/build/outputs/bundle/release/*.aab)" >> $GITHUB_OUTPUT
-
       - name: Get release file apk path
         id: releaseApk
         run: echo "apkfile=$(find app/build/outputs/apk/release/*.apk)" >> $GITHUB_OUTPUT
@@ -70,7 +66,6 @@ jobs:
         with:
           files: |
             ${{ steps.releaseApk.outputs.apkfile }}
-            ${{ steps.releaseAab.outputs.aabfile }}
           draft: true
           prerelease: true
           generate_release_notes: true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,14 @@ android {
             keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
         }
     }
+
+    applicationVariants.all {
+        outputs.all {
+            val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+            output.outputFileName = "FridaManager.apk"
+        }
+    }
+
     namespace = "sh.damon.fridamgr"
     compileSdk = 34
 
@@ -19,8 +27,8 @@ android {
         applicationId = "sh.damon.fridamgr"
         minSdk = 29
         targetSdk = 34
-        versionCode = 4
-        versionName = "0.1.3"
+        versionCode = 5
+        versionName = "0.1.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -35,6 +43,7 @@ android {
             signingConfig = signingConfigs.getByName("release")
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         minSdk = 29
         targetSdk = 34
         versionCode = 5
-        versionName = "0.1.5"
+        versionName = "0.1.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
# Changes
- Bumped version number 0.1.4
- Adapted release and debug apk names to FridaManager.apk
- Modified Github Action to no longer include the app-release.aab